### PR TITLE
I've added initial Markdown documentation for core ELSI modules.

### DIFF
--- a/docs/elsi_bsepack.md
+++ b/docs/elsi_bsepack.md
@@ -1,0 +1,31 @@
+# Overview
+
+This module provides an interface to the BSEPACK library, which is used to solve Bethe-Salpeter Equation (BSE) eigenproblems. It defines subroutines for both real and complex matrix types.
+
+# Key Components
+
+- `elsi_solve_bsepack_real`: Solves the BSE eigenproblem for real matrices using the `pdbseig` routine from BSEPACK.
+- `elsi_solve_bsepack_cmplx`: Solves the BSE eigenproblem for complex matrices using the `pzbseig` routine from BSEPACK.
+
+# Important Variables/Constants
+
+- `ph`: Input parameter of type `elsi_param_t`, containing ELSI parameters.
+- `bh`: Input parameter of type `elsi_basic_t`, containing basic ELSI information.
+- `mat_a`, `mat_b`: Input matrices for the eigenproblem.
+- `eval`: Output array for eigenvalues.
+- `evec`: Output array for eigenvectors.
+
+# Usage Examples
+
+The subroutines are called with ELSI parameters, matrices, and output arrays for eigenvalues and eigenvectors.
+
+```fortran
+! Example (conceptual)
+call elsi_solve_bsepack_real(ph, bh, mat_a, mat_b, eval, evec)
+call elsi_solve_bsepack_cmplx(ph, bh, mat_a_cmplx, mat_b_cmplx, eval_cmplx, evec_cmplx)
+```
+
+# Dependencies and Interactions
+
+- Depends on ELSI modules: `ELSI_DATATYPE`, `ELSI_MALLOC`, `ELSI_OUTPUT`, `ELSI_PRECISION`, `ELSI_UTIL`.
+- Interacts with the BSEPACK library through the `pdbseig` and `pzbseig` routines.

--- a/docs/elsi_c_interface.md
+++ b/docs/elsi_c_interface.md
@@ -1,0 +1,97 @@
+# Overview
+
+This module provides a C language interface to the ELSI (Electronic Structure Infrastructure) library. It allows C or C++ programs to call ELSI's Fortran subroutines by using the `ISO_C_BINDING` feature for interoperability. The primary mechanism involves passing a C pointer (`type(c_ptr)`) as a handle (`h_c`) which corresponds to an internal Fortran handle (`elsi_handle` or `elsi_rw_handle`).
+
+# Key Components
+
+The module defines a large number of C wrapper functions, typically prefixed with `c_elsi_`. These can be broadly categorized as:
+
+- **Initialization and Finalization:**
+    - `c_elsi_init`: Initializes an ELSI handle.
+    - `c_elsi_finalize`: Finalizes an ELSI handle and releases resources.
+    - `c_elsi_reinit`: Reinitializes an ELSI handle.
+- **Parameter Setting:**
+    - Functions to set MPI communicators, BLACS context, matrix distribution and format (CSC, COO).
+        - Example: `c_elsi_set_mpi`, `c_elsi_set_blacs`, `c_elsi_set_csc`
+    - Functions to set problem-specific parameters like number of spins, k-points, electron count, basis size.
+        - Example: `c_elsi_set_spin`, `c_elsi_set_kpoint`
+    - Functions to configure solver-specific settings for various eigensolvers and density matrix solvers (ELPA, OMM, PEXSI, EigenExa, SIPS, NTPoly, MAGMA).
+        - Example: `c_elsi_set_elpa_solver`, `c_elsi_set_pexsi_n_pole`, `c_elsi_set_ntpoly_method`
+    - Functions to set general options like output verbosity, file names, tolerances.
+        - Example: `c_elsi_set_input_file`, `c_elsi_set_output_log`, `c_elsi_set_mu_tol`
+- **Computational Routines:**
+    - Functions to perform eigenvalue calculations for real and complex, dense and sparse matrices.
+        - Example: `c_elsi_ev_real`, `c_elsi_ev_complex_sparse`
+    - Functions to calculate the density matrix for real and complex, dense and sparse matrices.
+        - Example: `c_elsi_dm_real`, `c_elsi_dm_complex_sparse`
+    - Functions to solve Bethe-Salpeter Equation (BSE) problems.
+        - Example: `c_elsi_bse_real`, `c_elsi_bse_complex`
+- **Data Retrieval:**
+    - Functions to get version information, timestamps.
+        - Example: `c_elsi_get_version`, `c_elsi_get_datestamp`
+    - Functions to retrieve results like eigenvalues, eigenvectors, occupation numbers, chemical potential, energy, entropy.
+        - Example: `c_elsi_get_eval`, `c_elsi_get_evec_real`, `c_elsi_get_mu`, `c_elsi_get_entropy`
+    - Functions to get error status or specific solver metrics.
+        - Example: `c_elsi_get_n_illcond`
+- **Matrix Operations:**
+    - Functions for orthonormalizing eigenvectors.
+        - Example: `c_elsi_orthonormalize_ev_real`
+    - Functions for extrapolating density matrices.
+        - Example: `c_elsi_extrapolate_dm_complex`
+- **Read/Write Functionality:**
+    - `c_elsi_init_rw`: Initializes a handle for read/write operations.
+    - `c_elsi_finalize_rw`: Finalizes the read/write handle.
+    - Functions to read matrix dimensions and data from files for dense and sparse matrices.
+        - Example: `c_elsi_read_mat_dim`, `c_elsi_read_mat_real_sparse`
+    - Functions to write matrix data to files for dense and sparse matrices.
+        - Example: `c_elsi_write_mat_complex`, `c_elsi_write_mat_real_sparse`
+- **Utility Functions:**
+    - `str_c2f`: Converts C-style strings (null-terminated) to Fortran-style strings. This is used internally when C functions pass string arguments to Fortran.
+
+# Important Variables/Constants
+
+- `h_c`: A `type(c_ptr)` which serves as an opaque handle for C programs to interact with the ELSI library. It is obtained from `c_elsi_init` (or `c_elsi_init_rw`) and passed to most other `c_elsi_...` functions.
+- Various integer and real type arguments for specifying parameters, matrix dimensions, tolerances, and for passing data arrays (e.g., `ham_c`, `ovlp_c`, `eval_c`, `evec_c`). These are typically passed as C pointers (`type(c_ptr)`) for arrays/matrices, which are then converted to Fortran pointers within the interface.
+
+# Usage Examples
+
+A typical workflow from C would involve:
+
+```c
+// Conceptual C example
+#include "elsi.h" // Assuming a C header file for ELSI C interface exists
+
+elsi_handle_c h; // This would be a C-compatible type for the handle (e.g., void*)
+int solver = ELSI_SOLVER_ELPA; // Example solver choice
+int parallel_mode = ELSI_PARALLEL_MODE_MPI; // Example parallel mode
+int matrix_format = ELSI_MATRIX_FORMAT_DENSE; // Example matrix format
+int n_basis = 100;
+double n_electron = 10.0;
+int n_state = 10;
+
+// Initialize ELSI
+c_elsi_init(&h, solver, parallel_mode, matrix_format, n_basis, n_electron, n_state);
+
+// Set MPI communicator (example, actual value depends on MPI setup)
+// c_elsi_set_mpi(h, mpi_comm_c);
+
+// ... set other parameters ...
+
+// Allocate and prepare matrices (ham_c, ovlp_c, eval_c, evec_c)
+
+// Perform eigenvalue calculation (real, dense example)
+// c_elsi_ev_real(h, ham_c_ptr, ovlp_c_ptr, eval_c_ptr, evec_c_ptr);
+
+// ... retrieve results ...
+// c_elsi_get_eval(h, eval_c_ptr);
+
+// Finalize ELSI
+c_elsi_finalize(h);
+```
+
+# Dependencies and Interactions
+
+- **ISO_C_BINDING:** This Fortran standard module is crucial for defining the C-compatible interfaces.
+- **ELSI Fortran library:** This module acts as a wrapper around the core Fortran routines of the ELSI library. The actual computations and logic reside in the Fortran part of ELSI.
+- **C/C++ calling code:** These C interface functions are intended to be called from user applications written in C or C++. The calling code needs to link against the compiled ELSI library.
+- **MPI and BLACS (optional):** For parallel execution, the C calling code and ELSI must be properly configured with MPI and potentially ScaLAPACK/BLACS.

--- a/docs/elsi_constant.md
+++ b/docs/elsi_constant.md
@@ -1,0 +1,84 @@
+# Overview
+
+The `ELSI_CONSTANT` module centralizes the definition of various integer and real constants that are used throughout the ELSI (Electronic Structure Infrastructure) library. These constants serve as standardized codes and parameters for selecting solvers, specifying matrix properties, controlling parallel execution, defining data types, and managing other operational aspects of ELSI.
+
+# Key Components
+
+This module does not define any functions, classes, or procedures. Its sole purpose is to declare named constants (`parameter` attributes).
+
+# Important Variables/Constants
+
+All constants defined in this module are significant for the configuration and operation of ELSI. They are grouped by their purpose:
+
+- **Mathematical Constants:**
+    - `SQRT_PI`: The square root of Pi.
+    - `INVERT_SQRT_PI`: The inverse of the square root of Pi.
+
+- **General Purpose Constants:**
+    - `UNSET`: A default integer value indicating an unset or undefined parameter.
+    - `N_SOLVERS`: Total number of available solver types.
+    - `N_MATRIX_FORMATS`: Total number of supported matrix formats.
+    - `N_PARALLEL_MODES`: Total number of parallelization modes.
+
+- **Solver Types:** Integer codes to identify different solvers.
+    - `AUTO_SOLVER`, `ELPA_SOLVER`, `OMM_SOLVER`, `PEXSI_SOLVER`, `EIGENEXA_SOLVER`, `SIPS_SOLVER`, `NTPOLY_SOLVER`, `MAGMA_SOLVER`, `BSEPACK_SOLVER`.
+
+- **Data Types:** Integer codes for real or complex data.
+    - `REAL_DATA`, `CMPLX_DATA`.
+
+- **Matrix Formats:** Integer codes for different matrix storage schemes.
+    - `BLACS_DENSE`: Dense matrix format using BLACS distribution.
+    - `PEXSI_CSC`: Compressed Sparse Column (CSC) format, compatible with PEXSI.
+    - `SIESTA_CSC`: CSC format, compatible with SIESTA.
+    - `GENERIC_COO`: Generic Coordinate (COO) sparse matrix format.
+
+- **Matrix Conversion Masks:** Integer codes for specifying which matrices (Hamiltonian H, Overlap S, or both HS) are involved in a conversion.
+    - `MASK_HS`, `MASK_H`, `MASK_S`.
+
+- **Triangular Matrix Types:** Integer codes for full, upper triangular, or lower triangular matrices.
+    - `FULL_MAT`, `UT_MAT`, `LT_MAT`.
+
+- **Parallelization Modes:** Integer codes for serial or parallel execution.
+    - `SINGLE_PROC`, `MULTI_PROC`.
+
+- **Broadening Schemes:** Integer codes for different electronic state broadening methods.
+    - `GAUSSIAN`, `FERMI`, `METHFESSEL_PAXTON`, `CUBIC`, `COLD`.
+
+- **Density Matrix Types:** Integer codes to specify the type of density matrix to compute or retrieve.
+    - `GET_DM` (Density Matrix), `GET_EDM` (Energy Density Matrix), `GET_FDM` (Free Energy Density Matrix).
+
+- **Frozen Core Methods:** Integer codes for different approaches to handling frozen core electrons.
+    - `FC_BASIC`, `FC_PLUS_C`, `FC_PLUS_V`.
+
+- **NTPoly Density Matrix Purification Methods:** Integer codes for purification algorithms in NTPoly.
+    - `NTPOLY_PM`, `NTPOLY_TRS2`, `NTPOLY_TRS4`, `NTPOLY_HPCP`.
+
+- **Density Matrix Extrapolation Methods:** Integer codes for density matrix extrapolation techniques.
+    - `EXTRA_FACTOR`, `EXTRA_TRS2`.
+
+- **Matrix Reading and Writing Parameters:**
+    - `HEADER_SIZE`: Size of the header in matrix files.
+    - `FILE_VERSION`: Version number for ELSI's matrix file format.
+    - `READ_FILE`: Task identifier for reading a file.
+    - `WRITE_FILE`: Task identifier for writing a file.
+
+# Usage Examples
+
+These constants are primarily used internally within ELSI to make decisions and configure operations. For instance, when a user specifies a solver via an input parameter, ELSI routines would compare this input against the defined solver constants:
+
+```fortran
+! In an ELSI internal routine
+if (user_input_solver == ELPA_SOLVER) then
+    call elsi_solve_elpa(...)
+else if (user_input_solver == PEXSI_SOLVER) then
+    call elsi_solve_pexsi(...)
+end if
+
+! When setting matrix properties
+call elsi_set_matrix_format(handle, GENERIC_COO)
+```
+
+# Dependencies and Interactions
+
+- **`ELSI_PRECISION`:** This module is used to define the precision (kind parameters `r8` for real, `i4` for integer) of the constants.
+- **Other ELSI Modules:** The constants defined here are extensively used throughout the ELSI library by other modules to ensure consistent parameter values and to control conditional logic.

--- a/docs/elsi_datatype.md
+++ b/docs/elsi_datatype.md
@@ -1,0 +1,97 @@
+# Overview
+
+The `ELSI_DATATYPE` module is a cornerstone of the ELSI (Electronic Structure Infrastructure) library, defining the essential derived data types (analogous to structures in C/C++) used to manage and store data throughout ELSI operations. These types encapsulate a wide array of information, including MPI/BLACS configurations, physical system parameters, matrix data, solver-specific settings, and operational handles.
+
+# Key Components (Derived Types)
+
+This module's primary role is the definition of the following derived types:
+
+- **`elsi_basic_t`**:
+    - **Purpose**: Stores fundamental information about the computational environment and matrix distribution.
+    - **Key Members**:
+        - I/O settings: `print_info`, `print_unit`, `print_json`.
+        - MPI details: `myid`, `n_procs`, `comm` (MPI communicator for the solver group), `comm_all` (global MPI communicator).
+        - BLACS grid information: `blacs_ctxt`, `desc` (ScaLAPACK descriptor), `n_prow`, `n_pcol`, `my_prow`, `my_pcol`, `n_lrow`, `n_lcol` (local matrix dimensions).
+        - Sparse matrix properties: `nnz_g` (global non-zeros), `nnz_l_sp` (local non-zeros for generic sparse format), `def0` (zero threshold), and format-specific non-zero counts and local column numbers for PEXSI CSC, SIESTA CSC, and Generic COO formats.
+
+- **`elsi_param_t`**:
+    - **Purpose**: Contains a comprehensive set of parameters that control the behavior of ELSI solvers and other functionalities.
+    - **Key Members**:
+        - General settings: `solver` (selected solver ID), `matrix_format`, `parallel_mode`.
+        - Overlap matrix handling: `save_ovlp`, `unit_ovlp`, `ill_check` (ill-conditioning check toggle), `ill_tol` (ill-conditioning tolerance), `ovlp_ev_min`/`_max`.
+        - Physical system details: `n_electrons`, `n_basis`, `n_spins`, `n_kpts`, `n_states` (number of states to find/use), `spin_degen`, `energy_gap`, `spectrum_width`.
+        - Chemical potential (`mu`) calculation: `mu_scheme`, `mu_width`, `mu_tol`.
+        - Frozen core options: `fc_method`, `n_basis_c` (core basis size), `n_basis_v` (valence basis size).
+        - Matrix redistribution flags and solver-specific parameter subsections for:
+            - ELPA: `elpa_solver` (1-stage/2-stage), `elpa_gpu`, `elpa_autotune`.
+            - libOMM: `omm_flavor`, `omm_tol`.
+            - PEXSI: `pexsi_np_per_pole`, `pexsi_mu_min`/`_max`, `pexsi_options` (native PEXSI options structure).
+            - EigenExa: `exa_method`.
+            - SLEPc-SIPs: `sips_n_slices`, `sips_interval`.
+            - NTPoly: `nt_method`, `nt_tol`, `nt_options` (native NTPoly options structure).
+            - MAGMA: `magma_solver`, `magma_n_gpus`.
+            - BSEPACK: `bse_n_lrow`, `bse_n_lcol`.
+
+- **`elsi_handle`**:
+    - **Purpose**: The primary opaque handle used in ELSI's main interface. It aggregates basic information, parameters, and data arrays.
+    - **Key Members**:
+        - `bh`: An instance of `elsi_basic_t`.
+        - `ph`: An instance of `elsi_param_t`.
+        - `jh`: An instance of `fjson_handle` for JSON logging.
+        - Allocatable arrays for dense matrices: `ham_real_den`, `ham_cmplx_den`, `ovlp_real_den`, `ovlp_cmplx_den`, `eval` (eigenvalues), `evec_real`, `evec_cmplx`, `dm_real_den`, `dm_cmplx_den`.
+        - Allocatable arrays for sparse matrices (CSC values, COO values/indices): `ham_real_sp`, `ovlp_cmplx_sp`, `row_ind_sp1`, `col_ptr_sp1`, etc.
+        - Native sparse matrix types for NTPoly: `nt_ham`, `nt_ovlp`, `nt_dm`.
+        - Data for frozen core calculations: `perm_fc` (permutation vector), `ham_real_v` (valence Hamiltonian).
+        - Auxiliary and temporary storage arrays used by various routines.
+        - `handle_init`: A logical flag indicating if the handle has been initialized.
+
+- **`elsi_rw_handle`**:
+    - **Purpose**: A specialized handle for matrix read and write operations.
+    - **Key Members**:
+        - `bh`: An instance of `elsi_basic_t`.
+        - `rw_task`: Specifies the operation (read or write).
+        - `parallel_mode`, `matrix_format`, `n_electrons`, `n_basis`.
+        - `header_user`: User-defined values in the matrix file header.
+        - `handle_init`: A logical flag indicating if the read/write handle has been initialized.
+
+# Important Variables/Constants
+
+The members within these derived types are crucial for ELSI's operation. For example:
+- `elsi_handle%bh%comm`: The MPI communicator for the current solver.
+- `elsi_handle%ph%solver`: The integer code for the chosen eigensolver or density matrix method.
+- `elsi_handle%ph%n_electrons`: The number of electrons in the system.
+- `elsi_handle%ham_real_den`: Array storing the Hamiltonian matrix (real, dense case).
+
+# Usage Examples
+
+These data types are instantiated and populated by ELSI's setup and interface routines. Users interacting with ELSI via its Fortran API would typically work with a variable of type `elsi_handle`.
+
+```fortran
+! Declaration of an ELSI handle
+type(elsi_handle) :: my_elsi_calculation
+
+! Initialization (simplified representation of what elsi_init does)
+call elsi_init(my_elsi_calculation, ELPA_SOLVER, MULTI_PROC, BLACS_DENSE, &
+               n_basis_val, n_electrons_val, n_states_val)
+
+! Setting a specific parameter after initialization
+my_elsi_calculation%ph%mu_tol = 1.0d-8
+
+! Accessing information from the handle
+if (my_elsi_calculation%bh%myid == 0) then
+  write(*,*) "ELSI calculation initialized for solver: ", my_elsi_calculation%ph%solver
+end if
+
+! Matrices are allocated and accessed via the handle, e.g.:
+! my_elsi_calculation%ham_real_den(i,j) = ...
+```
+
+# Dependencies and Interactions
+
+- **`ELSI_PRECISION`**: Provides kind parameters (`r8`, `i4`, `i8`) for defining the precision of numeric members.
+- **External Library Modules**:
+    - `ELPA`: For `elpa_t` (ELPA handle) and `elpa_autotune_t` (ELPA autotuning handle).
+    - `F_PPEXSI_INTERFACE`: For `f_ppexsi_options` (PEXSI options structure).
+    - `FORTJSON`: For `fjson_handle` (FortJSON logging handle).
+    - `NTPOLY`: For `Permutation_t`, `Matrix_ps` (NTPoly sparse matrix type), `SolverParameters_t`, `ProcessGrid_t`.
+- **Other ELSI Modules**: These data types are fundamental and are passed to and modified by most other modules within ELSI, particularly `ELSI_SETUP`, `ELSI_SET`, `ELSI_SOLVER`, and the various solver-specific interface modules.

--- a/docs/elsi_decision.md
+++ b/docs/elsi_decision.md
@@ -1,0 +1,88 @@
+# Overview
+
+The `ELSI_DECISION` module in the ELSI library is responsible for automatically selecting an appropriate eigensolver or density matrix (DM) solver if the user has specified `AUTO_SOLVER`. This selection process relies on a set of heuristics that consider matrix characteristics (size, sparsity), physical system properties (energy gap, dimensionality), and the configuration of available parallel solvers.
+
+# Key Components
+
+- **`elsi_decide_ev(ph, bh)`**:
+    - **Purpose**: Determines the eigensolver to be used when `ph%solver` is `AUTO_SOLVER`.
+    - **Logic**: Currently, this subroutine defaults to selecting the `ELPA_SOLVER`.
+    - **Arguments**:
+        - `ph` (inout, type `elsi_param_t`): ELSI parameter bundle, `ph%solver` is updated if it was `AUTO_SOLVER`.
+        - `bh` (in, type `elsi_basic_t`): Basic ELSI information.
+
+- **`elsi_decide_dm_real(ph, bh, mat)`**:
+    - **Purpose**: Determines the density matrix solver for real, dense input matrices (`mat`).
+    - **Logic**: Calculates the sparsity of the input matrix `mat` by counting elements above `bh%def0`. The global non-zero count is obtained via `MPI_Allreduce`. The calculated sparsity is then broadcasted and passed to `elsi_decide_dm_smart`.
+    - **Arguments**:
+        - `ph` (inout, type `elsi_param_t`): ELSI parameters; `ph%solver` is updated.
+        - `bh` (in, type `elsi_basic_t`): Basic ELSI information.
+        - `mat` (in, real(r8)): The local part of the dense real matrix.
+
+- **`elsi_decide_dm_cmplx(ph, bh, mat)`**:
+    - **Purpose**: Determines the density matrix solver for complex, dense input matrices (`mat`).
+    - **Logic**: Similar to `elsi_decide_dm_real`, but for complex matrices. Calculates sparsity and calls `elsi_decide_dm_smart`.
+    - **Arguments**:
+        - `ph` (inout, type `elsi_param_t`): ELSI parameters; `ph%solver` is updated.
+        - `bh` (in, type `elsi_basic_t`): Basic ELSI information.
+        - `mat` (in, complex(r8)): The local part of the dense complex matrix.
+
+- **`elsi_decide_dm_sparse(ph, bh)`**:
+    - **Purpose**: Determines the density matrix solver when the input matrix is already in a sparse format and its global non-zero count (`bh%nnz_g`) is known.
+    - **Logic**: Calculates sparsity based on `bh%nnz_g` and `ph%n_basis`. The sparsity is broadcasted and passed to `elsi_decide_dm_smart`.
+    - **Arguments**:
+        - `ph` (inout, type `elsi_param_t`): ELSI parameters; `ph%solver` is updated.
+        - `bh` (in, type `elsi_basic_t`): Basic ELSI information.
+
+- **`elsi_decide_dm_smart(ph, bh, sparsity)`**:
+    - **Purpose**: Contains the core decision-making logic for selecting a density matrix solver (PEXSI, NTPoly, or ELPA as a fallback).
+    - **Logic**: It evaluates conditions based on `ph%n_basis` (matrix size), `sparsity`, `ph%energy_gap`, `ph%dimensionality`, PEXSI availability (`elsi_get_pexsi_enabled`), and MPI process counts relative to PEXSI configuration (`ph%pexsi_options%nPoints`, `ph%pexsi_np_per_pole`).
+        - PEXSI is considered for large, sparse systems (e.g., `n_basis >= 20000`, `sparsity >= 0.95`) if enabled and MPI configuration is compatible, and typically for lower dimensionality systems.
+        - NTPoly is considered for very large, very sparse systems (e.g., `n_basis >= 50000`, `sparsity >= 0.98`) if the energy gap is not too small.
+        - If neither PEXSI nor NTPoly meets the criteria, or if `ph%solver` remains `AUTO_SOLVER` after checks, `ELPA_SOLVER` is chosen as the default.
+    - **Arguments**:
+        - `ph` (inout, type `elsi_param_t`): ELSI parameters; `ph%solver` is updated.
+        - `bh` (in, type `elsi_basic_t`): Basic ELSI information.
+        - `sparsity` (in, real(r8)): The calculated sparsity of the Hamiltonian matrix.
+
+# Important Variables/Constants
+
+- `ph%solver`: (Input/Output) If `AUTO_SOLVER`, it's updated to `ELPA_SOLVER`, `PEXSI_SOLVER`, or `NTPOLY_SOLVER`.
+- `ph%n_basis`: (Input) Global dimension of the problem.
+- `bh%def0`: (Input) Threshold to consider a matrix element non-zero when calculating sparsity for dense matrices.
+- `bh%nnz_g`: (Input) Global number of non-zero elements, used by `elsi_decide_dm_sparse`.
+- `ph%energy_gap`: (Input) Estimated fundamental energy gap of the material.
+- `ph%dimensionality`: (Input) Dimensionality of the system (e.g., 1D, 2D, 3D).
+- `AUTO_SOLVER`, `ELPA_SOLVER`, `PEXSI_SOLVER`, `NTPOLY_SOLVER`: Constants representing solver choices.
+
+# Usage Examples
+
+These subroutines are intended for internal use by the ELSI library. They are invoked at the beginning of a calculation if the user has requested automatic solver selection.
+
+```fortran
+! Inside an ELSI routine, before calling a specific solver
+if (handle%ph%solver == AUTO_SOLVER) then
+    ! For a density matrix calculation with a real, dense Hamiltonian:
+    call elsi_decide_dm_real(handle%ph, handle%bh, handle%ham_real_den)
+    ! Now handle%ph%solver will be set to ELPA_SOLVER, PEXSI_SOLVER, or NTPOLY_SOLVER
+end if
+
+! Subsequent logic will use the determined handle%ph%solver
+select case (handle%ph%solver)
+    case (ELPA_SOLVER)
+        call elsi_solve_elpa_dm(...)
+    case (PEXSI_SOLVER)
+        call elsi_solve_pexsi_dm(...)
+    ! ... and so on
+end select
+```
+
+# Dependencies and Interactions
+
+- **`ELSI_CONSTANT`**: Provides constants for solver types (`AUTO_SOLVER`, `ELPA_SOLVER`, etc.).
+- **`ELSI_DATATYPE`**: Defines the `elsi_param_t` and `elsi_basic_t` derived types.
+- **`ELSI_MPI`**: Used for MPI communication primitives like `MPI_Allreduce` and `MPI_Bcast` to gather global information for decision making.
+- **`ELSI_OUTPUT`**: Used for logging the automatically selected solver via `elsi_say`.
+- **`ELSI_PRECISION`**: Provides definitions for real and integer kinds.
+- **`ELSI_UTIL`**: For utility functions like `elsi_check_err`.
+- The routine `elsi_get_pexsi_enabled` is called to check if PEXSI is available. (Note: Its module of origin should be ensured via a `use` statement if not part of a larger `use ELSI`).

--- a/documentation_template.md
+++ b/documentation_template.md
@@ -1,0 +1,19 @@
+# Overview
+
+[Brief description of what the code file does and its role within the larger project.]
+
+# Key Components
+
+[List of the primary functions, classes, or modules defined in the file, with a short description of each.]
+
+# Important Variables/Constants
+
+[Descriptions of any critical variables or constants defined in the file that affect its behavior.]
+
+# Usage Examples
+
+[If applicable, provide examples or code snippets demonstrating how to use the functions, classes, or modules in the file.]
+
+# Dependencies and Interactions
+
+[Notes on any dependencies the file has on other parts of the system or external libraries, and how it interacts with other components.]


### PR DESCRIPTION
This commit introduces Markdown documentation for the following five key Fortran modules from the `src/` directory:

- `elsi_bsepack.f90`: Interface to the BSEPACK library for Bethe-Salpeter Equation eigenproblems.
- `elsi_c_interface.f90`: C language interface for ELSI routines using ISO_C_BINDING.
- `elsi_constant.f90`: Defines various global constants used throughout ELSI.
- `elsi_datatype.f90`: Defines core derived data types (elsi_handle, elsi_param_t, etc.).
- `elsi_decision.f90`: Logic for automatically selecting solvers when not specified by you.

I created a documentation template (`documentation_template.md`) and used it as a basis for these files. Each `.md` file includes sections for Overview, Key Components, Important Variables/Constants, Usage Examples, and Dependencies and Interactions.

These files are placed in a new `docs/` directory. This is the first batch of documentation I've generated based on your request.